### PR TITLE
[FIX] account_receipt_sale: In migration, set negative quantities for receipt refunds

### DIFF
--- a/account_receipt_sale/__manifest__.py
+++ b/account_receipt_sale/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Receipts from sales",
     "summary": "Generate receipts from sale orders",
-    "version": "14.0.1.0.0",
+    "version": "14.0.1.0.1",
     "development_status": "Beta",
     "category": "Sales/Sales",
     "website": "https://github.com/OCA/account-invoicing",

--- a/account_receipt_sale/migrations/14.0.1.0.1/post-migrate.py
+++ b/account_receipt_sale/migrations/14.0.1.0.1/post-migrate.py
@@ -1,0 +1,11 @@
+#  Copyright 2023 Simone Rubino - TAKOBI
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+from odoo.addons.account_receipt_sale import invert_receipt_refund_quantity
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    invert_receipt_refund_quantity(env)


### PR DESCRIPTION
To be included in https://github.com/OCA/account-invoicing/pull/1267.